### PR TITLE
connect to nreplds:/// URIS from shell using lein nreplds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ and use the standard `clojure.tools.nrepl/url-connect` with a URI like
 `nreplds:///path/to/sock.sock`. Because of an implementation detail the path must
 be absolute.
 
-To add `nreplds:///` URIs to `lein repl`, add `[lein-nreplds "0.1"]` to your
-leiningen plugins. Now you can connect to a UDS using `lein repl :connect
+To connect to `nreplds:///` URIs from shell, add `[lein-nreplds "0.1.1"]` to your
+leiningen plugins. Now you can connect to a UDS using `lein nreplds :connect
 nreplds:///path/to/sock.sock`. Because of an implementation detail the path must
-be absolute.
+be absolute. This connection to `nreplds:///` from shell only tested in leiningen 2.4.2.
 
 Forwarding a UDS over SSH
 =========================

--- a/lein-nreplds/project.clj
+++ b/lein-nreplds/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-nreplds "0.1"
+(defproject lein-nreplds "0.1.1"
   :description "Unix domain socket support for nREPL"
   :url "https://github.com/monsanto/nreplds"
   :license {:name "Eclipse Public License"

--- a/lein-nreplds/src/lein_nreplds/plugin.clj
+++ b/lein-nreplds/src/lein_nreplds/plugin.clj
@@ -1,4 +1,0 @@
-
-(ns lein-nreplds.plugin
-  (:require nreplds.core))
-

--- a/lein-nreplds/src/leiningen/nreplds.clj
+++ b/lein-nreplds/src/leiningen/nreplds.clj
@@ -1,0 +1,16 @@
+(ns leiningen.nreplds
+  (require [robert.hooke]
+           [leiningen.repl]))
+
+(defn skip-ensure-port-number
+  "leiningen version 2.4.2 (at least) use ensure-port to force port number usage. this hook skip the execution."
+  [f s]
+  s)
+
+(defn ^:no-project-needed nreplds
+  [project & args]
+  (robert.hooke/with-scope
+    (robert.hooke/add-hook #'leiningen.repl/ensure-port #'leiningen.nreplds/skip-ensure-port-number)
+    (apply leiningen.repl/repl project args)
+    ))
+  


### PR DESCRIPTION
I can not connect to my nreplds:/// URI using `lein repl :connect nreplds:///.....` because your lein-nreplds does not work.

When I look at the code, It is not the way the leiningen plugin code should be, so I try to make it myself.

according to docs here https://github.com/technomancy/leiningen/blob/b9dced16d581beaf1657b69ac4d93697e322d83a/doc/PLUGINS.md, it is hard to shadow current repl command. So I create nreplds command to connect to nreplds:/// URIS.

You can run it like 

`lein nreplds :connect nreplds:///absolute-path-to-unix-domain-socket`

I only test it in leiningen version 2.4.2.

what it does is running `leiningen.repl/repl` but skipping `leiningen.repl/ensure-port` execution because at my current test environment (leiningen 2.4.2), leiningen requires that host has port. It's just a ugly hack, but I need to make sure that I can make the plugin. 

I'm still looking a way to make this plugin works on all leiningen version 2>.

What do you think?
